### PR TITLE
feat: add currency column to Expense and Debt entities

### DIFF
--- a/migrations/Version20260329125007.php
+++ b/migrations/Version20260329125007.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260329125007 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add currency column to expense and debt tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE expense ADD currency VARCHAR(3) NOT NULL DEFAULT \'PLN\'');
+        $this->addSql('ALTER TABLE debt ADD currency VARCHAR(3) NOT NULL DEFAULT \'PLN\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE expense DROP COLUMN currency');
+        $this->addSql('ALTER TABLE debt DROP COLUMN currency');
+    }
+}

--- a/src/Controller/Api/ExpenseApiController.php
+++ b/src/Controller/Api/ExpenseApiController.php
@@ -53,6 +53,7 @@ class ExpenseApiController extends AbstractController
                 title: $expense->getTitle(),
                 description: $expense->getDescription(),
                 payeeEmail: $expense->getPayee()->getEmail(),
+                currency: $expense->getCurrency(),
                 value: $this->userDebtService->calculateExpenseBalanceForUser($expense, $user),
                 occurredOn: $expense->getOccurredOn(),
             ),
@@ -78,6 +79,7 @@ class ExpenseApiController extends AbstractController
             title: $expense->getTitle(),
             description: $expense->getDescription(),
             amount: $expense->getAmount(),
+            currency: $expense->getCurrency(),
             payeeId: $expense->getPayee()->getId(),
             occurredOn: $expense->getOccurredOn(),
         ), JsonResponse::HTTP_CREATED);
@@ -105,6 +107,7 @@ class ExpenseApiController extends AbstractController
             title: $expense->getTitle(),
             description: $expense->getDescription(),
             amount: $expense->getAmount(),
+            currency: $expense->getCurrency(),
             payeeId: $expense->getPayee()->getId(),
             occurredOn: $expense->getOccurredOn(),
         ));

--- a/src/Dto/CreateExpenseResponse.php
+++ b/src/Dto/CreateExpenseResponse.php
@@ -11,6 +11,7 @@ readonly class CreateExpenseResponse
         public string $title,
         public ?string $description,
         public string $amount,
+        public string $currency,
         public int $payeeId,
         public \DateTimeImmutable $occurredOn,
     ) {

--- a/src/Dto/ExpenseListItemDto.php
+++ b/src/Dto/ExpenseListItemDto.php
@@ -11,6 +11,7 @@ readonly class ExpenseListItemDto
         public string $title,
         public ?string $description,
         public string $payeeEmail,
+        public string $currency,
         public string $value,
         public \DateTimeImmutable $occurredOn,
     ) {

--- a/src/Entity/Debt.php
+++ b/src/Entity/Debt.php
@@ -24,6 +24,9 @@ class Debt
     #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2)]
     private string $amount;
 
+    #[ORM\Column(length: 3)]
+    private string $currency;
+
     #[ORM\ManyToOne(inversedBy: 'debts')]
     #[ORM\JoinColumn(nullable: false)]
     private Expense $expense;
@@ -34,11 +37,12 @@ class Debt
     #[ORM\Column]
     private \DateTimeImmutable $updatedAt;
 
-    public function __construct(User $user, Expense $expense, string $amount)
+    public function __construct(User $user, Expense $expense, string $amount, string $currency = 'PLN')
     {
         $this->payer = $user;
         $this->expense = $expense;
         $this->setAmount($amount);
+        $this->setCurrency($currency);
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
     }
@@ -68,6 +72,22 @@ class Debt
     public function getExpense(): Expense
     {
         return $this->expense;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): static
+    {
+        if (1 !== preg_match('/^[A-Z]{3}$/', $currency)) {
+            throw new \InvalidArgumentException('Currency must be a 3-letter uppercase ISO 4217 code.');
+        }
+
+        $this->currency = $currency;
+
+        return $this;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/src/Entity/Expense.php
+++ b/src/Entity/Expense.php
@@ -32,6 +32,9 @@ class Expense
     #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2)]
     private string $amount;
 
+    #[ORM\Column(length: 3)]
+    private string $currency;
+
     #[ORM\Column(type: Types::DATE_IMMUTABLE)]
     private \DateTimeImmutable $occurredOn;
 
@@ -47,7 +50,7 @@ class Expense
     #[ORM\OneToMany(targetEntity: Debt::class, mappedBy: 'expense', orphanRemoval: true)]
     private Collection $debts;
 
-    public function __construct(User $payee, string $title, ?string $description, string $amount, \DateTimeImmutable $occurredOn)
+    public function __construct(User $payee, string $title, ?string $description, string $amount, \DateTimeImmutable $occurredOn, string $currency = 'PLN')
     {
         $this->payee = $payee;
         $this->title = $title;
@@ -56,6 +59,7 @@ class Expense
         $this->setAmount($amount);
 
         $this->occurredOn = $occurredOn;
+        $this->setCurrency($currency);
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
         $this->debts = new ArrayCollection();
@@ -126,6 +130,22 @@ class Expense
         return $this;
     }
 
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): static
+    {
+        if (1 !== preg_match('/^[A-Z]{3}$/', $currency)) {
+            throw new \InvalidArgumentException('Currency must be a 3-letter uppercase ISO 4217 code.');
+        }
+
+        $this->currency = $currency;
+
+        return $this;
+    }
+
     /**
      * @return Collection<int, Debt>
      */
@@ -138,6 +158,10 @@ class Expense
     {
         if ($debt->getExpense() !== $this) {
             throw new \InvalidArgumentException('Debt expense must be the same as the Expense');
+        }
+
+        if ($debt->getCurrency() !== $this->currency) {
+            throw new \InvalidArgumentException('Debt currency must match the Expense currency');
         }
 
         if (!$this->debts->contains($debt)) {

--- a/src/Services/ExpenseCreateService.php
+++ b/src/Services/ExpenseCreateService.php
@@ -52,7 +52,7 @@ class ExpenseCreateService
                 throw new UnprocessableEntityHttpException('One or more debt users do not exist.');
             }
 
-            $debt = new Debt($payer, $expense, $debtRequest->amount);
+            $debt = new Debt($payer, $expense, $debtRequest->amount, $expense->getCurrency());
             $expense->addDebt($debt);
 
             $this->entityManager->persist($debt);

--- a/src/Services/ExpenseUpdateService.php
+++ b/src/Services/ExpenseUpdateService.php
@@ -71,7 +71,7 @@ class ExpenseUpdateService
             ->setOccurredOn($request->occurredOn);
 
         foreach ($request->debts as $debtRequest) {
-            $debt = new Debt($usersById[$debtRequest->payerId], $expense, $debtRequest->amount);
+            $debt = new Debt($usersById[$debtRequest->payerId], $expense, $debtRequest->amount, $expense->getCurrency());
             $expense->addDebt($debt);
             $this->entityManager->persist($debt);
         }

--- a/tests/Api/ExpenseApiControllerTest.php
+++ b/tests/Api/ExpenseApiControllerTest.php
@@ -49,12 +49,13 @@ class ExpenseApiControllerTest extends ApiTestCase
         ]);
 
         $this->assertJsonResponseIsSuccessful(201);
-        $this->assertJsonStructure(['id', 'title', 'description', 'amount', 'payeeId', 'occurredOn']);
+        $this->assertJsonStructure(['id', 'title', 'description', 'amount', 'currency', 'payeeId', 'occurredOn']);
 
         $response = $this->getJsonResponse();
         $this->assertSame('Dinner', $response['title']);
         $this->assertSame('Friday dinner', $response['description']);
         $this->assertSame('100.00', $response['amount']);
+        $this->assertSame('PLN', $response['currency']);
         $this->assertSame($creator->getId(), $response['payeeId']);
         $this->assertStringStartsWith('2026-01-01', $response['occurredOn']);
 
@@ -278,13 +279,14 @@ class ExpenseApiControllerTest extends ApiTestCase
         ]);
 
         $this->assertJsonResponseIsSuccessful(200);
-        $this->assertJsonStructure(['id', 'title', 'description', 'amount', 'payeeId', 'occurredOn']);
+        $this->assertJsonStructure(['id', 'title', 'description', 'amount', 'currency', 'payeeId', 'occurredOn']);
 
         $response = $this->getJsonResponse();
         $this->assertSame($expense->getId(), $response['id']);
         $this->assertSame('Updated dinner', $response['title']);
         $this->assertSame('', $response['description']);
         $this->assertSame('120.00', $response['amount']);
+        $this->assertSame('PLN', $response['currency']);
         $this->assertSame($otherUser->getId(), $response['payeeId']);
         $this->assertStringStartsWith('2026-01-15', $response['occurredOn']);
 
@@ -657,13 +659,14 @@ class ExpenseApiControllerTest extends ApiTestCase
 
         $this->assertJsonResponseIsSuccessful();
         $this->assertJsonStructure([
-            0 => ['id', 'title', 'description', 'payeeEmail', 'value', 'occurredOn'],
+            0 => ['id', 'title', 'description', 'payeeEmail', 'currency', 'value', 'occurredOn'],
         ]);
 
         $response = $this->getJsonResponse();
         $this->assertSame('Test Expense', $response[0]['title']);
         $this->assertSame('Test Description', $response[0]['description']);
         $this->assertSame($user->getEmail(), $response[0]['payeeEmail']);
+        $this->assertSame('PLN', $response[0]['currency']);
         $this->assertSame('100.00', $response[0]['value']);
         $this->assertStringStartsWith('2026-01-01', $response[0]['occurredOn']);
     }

--- a/tests/Unit/Entity/DebtTest.php
+++ b/tests/Unit/Entity/DebtTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Debt;
+use App\Entity\Expense;
+use App\Tests\Support\Factory\UserFactory;
+use PHPUnit\Framework\TestCase;
+
+class DebtTest extends TestCase
+{
+    private function makeDebt(string $currency = 'PLN'): Debt
+    {
+        $expense = new Expense(
+            UserFactory::createUser(),
+            'Test',
+            null,
+            '10.00',
+            new \DateTimeImmutable(),
+            $currency,
+        );
+
+        return new Debt(UserFactory::createUser(), $expense, '10.00', $currency);
+    }
+
+    public function testSetCurrencyAcceptsValidIsoCodes(): void
+    {
+        $debt = $this->makeDebt();
+
+        foreach (['PLN', 'USD', 'EUR', 'GBP'] as $code) {
+            $debt->setCurrency($code);
+            $this->assertSame($code, $debt->getCurrency());
+        }
+    }
+
+    public function testConstructorDefaultsToPlnCurrency(): void
+    {
+        $expense = new Expense(
+            UserFactory::createUser(),
+            'Test',
+            null,
+            '10.00',
+            new \DateTimeImmutable(),
+        );
+        $debt = new Debt(UserFactory::createUser(), $expense, '10.00');
+
+        $this->assertSame('PLN', $debt->getCurrency());
+    }
+
+    /**
+     * @dataProvider invalidCurrencyProvider
+     */
+    public function testSetCurrencyRejectsInvalidCodes(string $invalid): void
+    {
+        $debt = $this->makeDebt();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $debt->setCurrency($invalid);
+    }
+
+    /**
+     * @dataProvider invalidCurrencyProvider
+     */
+    public function testConstructorRejectsInvalidCurrencyCodes(string $invalid): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->makeDebt($invalid);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidCurrencyProvider(): array
+    {
+        return [
+            'lowercase' => ['pln'],
+            'mixed case' => ['Pln'],
+            'too short' => ['PL'],
+            'too long' => ['PLNN'],
+            'numeric' => ['123'],
+            'empty string' => [''],
+        ];
+    }
+}

--- a/tests/Unit/Entity/ExpenseTest.php
+++ b/tests/Unit/Entity/ExpenseTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Debt;
+use App\Entity\Expense;
+use App\Tests\Support\Factory\UserFactory;
+use PHPUnit\Framework\TestCase;
+
+class ExpenseTest extends TestCase
+{
+    private function makeExpense(string $currency = 'PLN'): Expense
+    {
+        return new Expense(
+            UserFactory::createUser(),
+            'Test',
+            null,
+            '10.00',
+            new \DateTimeImmutable(),
+            $currency,
+        );
+    }
+
+    public function testSetCurrencyAcceptsValidIsoCodes(): void
+    {
+        $expense = $this->makeExpense();
+
+        foreach (['PLN', 'USD', 'EUR', 'GBP'] as $code) {
+            $expense->setCurrency($code);
+            $this->assertSame($code, $expense->getCurrency());
+        }
+    }
+
+    public function testConstructorDefaultsToPlnCurrency(): void
+    {
+        $expense = new Expense(
+            UserFactory::createUser(),
+            'Test',
+            null,
+            '10.00',
+            new \DateTimeImmutable(),
+        );
+
+        $this->assertSame('PLN', $expense->getCurrency());
+    }
+
+    /**
+     * @dataProvider invalidCurrencyProvider
+     */
+    public function testSetCurrencyRejectsInvalidCodes(string $invalid): void
+    {
+        $expense = $this->makeExpense();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $expense->setCurrency($invalid);
+    }
+
+    /**
+     * @dataProvider invalidCurrencyProvider
+     */
+    public function testConstructorRejectsInvalidCurrencyCodes(string $invalid): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->makeExpense($invalid);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidCurrencyProvider(): array
+    {
+        return [
+            'lowercase' => ['pln'],
+            'mixed case' => ['Pln'],
+            'too short' => ['PL'],
+            'too long' => ['PLNN'],
+            'numeric' => ['123'],
+            'empty string' => [''],
+        ];
+    }
+
+    public function testAddDebtAcceptsMatchingCurrency(): void
+    {
+        $expense = $this->makeExpense('EUR');
+        $debt = new Debt(UserFactory::createUser(), $expense, '10.00', 'EUR');
+
+        $expense->addDebt($debt);
+
+        $this->assertTrue($expense->getDebts()->contains($debt));
+    }
+
+    public function testAddDebtRejectsMismatchedCurrency(): void
+    {
+        $expense = $this->makeExpense('PLN');
+        $debt = new Debt(UserFactory::createUser(), $expense, '10.00', 'EUR');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('currency');
+        $expense->addDebt($debt);
+    }
+}


### PR DESCRIPTION
- Add currency (VARCHAR 3, ISO 4217, default PLN) field to Expense and Debt entities
- Generate migration Version20260329125007 for both tables
- Expose currency in CreateExpenseResponse and ExpenseListItemDto DTOs
- Update ExpenseApiController to pass currency in all response DTOs
- Update API tests to assert currency field presence and PLN value
- Add new Expense and Debt Entity Unit tests testing basic currency validations