### PR TITLE
feat: add transfer (settlement) CRUD API and balance netting

### DIFF
--- a/migrations/Version20260619213045.php
+++ b/migrations/Version20260619213045.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260619213045 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create transfer table for settlements between users';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE transfer (id INT AUTO_INCREMENT NOT NULL, payer_id INT NOT NULL, payee_id INT NOT NULL, amount NUMERIC(10, 2) NOT NULL, currency VARCHAR(3) NOT NULL, occurred_on DATE NOT NULL COMMENT \'(DC2Type:date_immutable)\', description LONGTEXT DEFAULT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_4034A3C0C17AD9A9 (payer_id), INDEX IDX_4034A3C0CB4B68F (payee_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE transfer ADD CONSTRAINT FK_4034A3C0C17AD9A9 FOREIGN KEY (payer_id) REFERENCES user (id)');
+        $this->addSql('ALTER TABLE transfer ADD CONSTRAINT FK_4034A3C0CB4B68F FOREIGN KEY (payee_id) REFERENCES user (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE transfer DROP FOREIGN KEY FK_4034A3C0C17AD9A9');
+        $this->addSql('ALTER TABLE transfer DROP FOREIGN KEY FK_4034A3C0CB4B68F');
+        $this->addSql('DROP TABLE transfer');
+    }
+}

--- a/src/Controller/Api/TransferApiController.php
+++ b/src/Controller/Api/TransferApiController.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Dto\TransferRequest;
+use App\Dto\TransferResponse;
+use App\Dto\TransferUpdateRequest;
+use App\Entity\Transfer;
+use App\Entity\User;
+use App\Repository\TransferRepository;
+use App\Services\TransferService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api')]
+class TransferApiController extends AbstractController
+{
+    public function __construct(
+        private readonly TransferRepository $transferRepository,
+        private readonly TransferService $transferService,
+    ) {
+    }
+
+    #[Route('/transfers', name: 'api_transfers_create', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    public function create(
+        #[MapRequestPayload(acceptFormat: 'json', validationFailedStatusCode: JsonResponse::HTTP_BAD_REQUEST)]
+        TransferRequest $request,
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $transfer = $this->transferService->create($user, $request);
+
+        return $this->json($this->toResponse($transfer), JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/transfers/{id}', name: 'api_transfers_update', methods: ['PUT'])]
+    #[IsGranted('ROLE_USER')]
+    public function update(
+        int $id,
+        #[MapRequestPayload(acceptFormat: 'json', validationFailedStatusCode: JsonResponse::HTTP_BAD_REQUEST)]
+        TransferUpdateRequest $request,
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $transfer = $this->transferRepository->find($id);
+        if (null === $transfer) {
+            throw $this->createNotFoundException('Transfer not found.');
+        }
+
+        $transfer = $this->transferService->update($user, $transfer, $request);
+
+        return $this->json($this->toResponse($transfer));
+    }
+
+    #[Route('/transfers/{id}', name: 'api_transfers_delete', methods: ['DELETE'])]
+    #[IsGranted('ROLE_USER')]
+    public function delete(int $id): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $transfer = $this->transferRepository->find($id);
+        if (null === $transfer) {
+            throw $this->createNotFoundException('Transfer not found.');
+        }
+
+        $this->transferService->delete($user, $transfer);
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function toResponse(Transfer $transfer): TransferResponse
+    {
+        return new TransferResponse(
+            id: $transfer->getId(),
+            payerId: $transfer->getPayer()->getId(),
+            payeeId: $transfer->getPayee()->getId(),
+            amount: $transfer->getAmount(),
+            currency: $transfer->getCurrency(),
+            occurredOn: $transfer->getOccurredOn(),
+            description: $transfer->getDescription(),
+        );
+    }
+}

--- a/src/Dto/TransferRequest.php
+++ b/src/Dto/TransferRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Validator\Constraints\Decimal;
+use Symfony\Component\Validator\Constraints as Assert;
+
+readonly class TransferRequest
+{
+    public function __construct(
+        #[Assert\Positive]
+        public int $payerId,
+
+        #[Assert\Positive]
+        public int $payeeId,
+
+        #[Assert\Positive]
+        #[Decimal(scale: 2)]
+        public string $amount,
+
+        public \DateTimeImmutable $occurredOn,
+
+        public ?string $description = null,
+    ) {
+    }
+}

--- a/src/Dto/TransferResponse.php
+++ b/src/Dto/TransferResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+readonly class TransferResponse
+{
+    public function __construct(
+        public int $id,
+        public int $payerId,
+        public int $payeeId,
+        public string $amount,
+        public string $currency,
+        public \DateTimeImmutable $occurredOn,
+        public ?string $description,
+    ) {
+    }
+}

--- a/src/Dto/TransferUpdateRequest.php
+++ b/src/Dto/TransferUpdateRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Validator\Constraints\Decimal;
+use Symfony\Component\Validator\Constraints as Assert;
+
+readonly class TransferUpdateRequest
+{
+    public function __construct(
+        #[Assert\Positive]
+        #[Decimal(scale: 2)]
+        public string $amount,
+
+        public \DateTimeImmutable $occurredOn,
+
+        public ?string $description = null,
+    ) {
+    }
+}

--- a/src/Entity/Transfer.php
+++ b/src/Entity/Transfer.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\TransferRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: TransferRepository::class)]
+#[ORM\HasLifecycleCallbacks]
+class Transfer
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'transfersSent')]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $payer;
+
+    #[ORM\ManyToOne(inversedBy: 'transfersReceived')]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $payee;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2)]
+    private string $amount;
+
+    #[ORM\Column(length: 3)]
+    private string $currency;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    private \DateTimeImmutable $occurredOn;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $description;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(User $payer, User $payee, string $amount, \DateTimeImmutable $occurredOn, ?string $description = null, string $currency = 'PLN')
+    {
+        if ($payer === $payee) {
+            throw new \InvalidArgumentException('Transfer payer and payee must be different users.');
+        }
+
+        $this->payer = $payer;
+        $this->payee = $payee;
+        $this->occurredOn = $occurredOn;
+        $this->description = $description;
+
+        $this->setAmount($amount);
+        $this->setCurrency($currency);
+
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPayer(): User
+    {
+        return $this->payer;
+    }
+
+    public function getPayee(): User
+    {
+        return $this->payee;
+    }
+
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(string $amount): static
+    {
+        $this->amount = bcadd($amount, '0', 2);
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): static
+    {
+        if (1 !== preg_match('/^[A-Z]{3}$/', $currency)) {
+            throw new \InvalidArgumentException('Currency must be a 3-letter uppercase ISO 4217 code.');
+        }
+
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getOccurredOn(): \DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function setOccurredOn(\DateTimeImmutable $occurredOn): static
+    {
+        $this->occurredOn = $occurredOn;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    #[ORM\PreUpdate]
+    public function refreshUpdatedAt(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -48,12 +48,26 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(targetEntity: Expense::class, mappedBy: 'payee', orphanRemoval: true)]
     private Collection $expenses;
 
+    /**
+     * @var Collection<int, Transfer>
+     */
+    #[ORM\OneToMany(targetEntity: Transfer::class, mappedBy: 'payer', orphanRemoval: true)]
+    private Collection $transfersSent;
+
+    /**
+     * @var Collection<int, Transfer>
+     */
+    #[ORM\OneToMany(targetEntity: Transfer::class, mappedBy: 'payee', orphanRemoval: true)]
+    private Collection $transfersReceived;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
         $this->debts = new ArrayCollection();
         $this->expenses = new ArrayCollection();
+        $this->transfersSent = new ArrayCollection();
+        $this->transfersReceived = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -166,6 +180,48 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
         if (!$this->expenses->contains($expense)) {
             $this->expenses->add($expense);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Transfer>
+     */
+    public function getTransfersSent(): Collection
+    {
+        return $this->transfersSent;
+    }
+
+    public function addTransferSent(Transfer $transfer): static
+    {
+        if ($transfer->getPayer() !== $this) {
+            throw new \InvalidArgumentException('Transfer payer must be the same as the User');
+        }
+
+        if (!$this->transfersSent->contains($transfer)) {
+            $this->transfersSent->add($transfer);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Transfer>
+     */
+    public function getTransfersReceived(): Collection
+    {
+        return $this->transfersReceived;
+    }
+
+    public function addTransferReceived(Transfer $transfer): static
+    {
+        if ($transfer->getPayee() !== $this) {
+            throw new \InvalidArgumentException('Transfer payee must be the same as the User');
+        }
+
+        if (!$this->transfersReceived->contains($transfer)) {
+            $this->transfersReceived->add($transfer);
         }
 
         return $this;

--- a/src/Repository/TransferRepository.php
+++ b/src/Repository/TransferRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Transfer;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Transfer>
+ */
+class TransferRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Transfer::class);
+    }
+}

--- a/src/Services/TransferService.php
+++ b/src/Services/TransferService.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Dto\TransferRequest;
+use App\Dto\TransferUpdateRequest;
+use App\Entity\Transfer;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+class TransferService
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function create(User $creator, TransferRequest $request): Transfer
+    {
+        if ($request->payerId === $request->payeeId) {
+            throw new BadRequestHttpException('Transfer payer and payee must be different.');
+        }
+
+        $usersById = $this->userRepository->findIndexedById([$request->payerId, $request->payeeId]);
+
+        $payer = $usersById[$request->payerId] ?? null;
+        $payee = $usersById[$request->payeeId] ?? null;
+        if (null === $payer || null === $payee) {
+            throw new UnprocessableEntityHttpException('Payer or payee user does not exist.');
+        }
+
+        $creatorId = $creator->getId();
+        if (null === $creatorId || !in_array($creatorId, [$request->payerId, $request->payeeId], true)) {
+            throw new UnprocessableEntityHttpException('Creator must be the payer or the payee.');
+        }
+
+        $transfer = new Transfer($payer, $payee, $request->amount, $request->occurredOn, $request->description);
+
+        $this->entityManager->persist($transfer);
+        $this->entityManager->flush();
+
+        return $transfer;
+    }
+
+    public function update(User $editor, Transfer $transfer, TransferUpdateRequest $request): Transfer
+    {
+        if (!$this->isUserInvolved($editor, $transfer)) {
+            throw new AccessDeniedHttpException('Editor must be involved in the transfer.');
+        }
+
+        $transfer
+            ->setAmount($request->amount)
+            ->setOccurredOn($request->occurredOn)
+            ->setDescription($request->description);
+
+        $this->entityManager->flush();
+
+        return $transfer;
+    }
+
+    public function delete(User $editor, Transfer $transfer): void
+    {
+        if (!$this->isUserInvolved($editor, $transfer)) {
+            throw new AccessDeniedHttpException('Editor must be involved in the transfer.');
+        }
+
+        $this->entityManager->remove($transfer);
+        $this->entityManager->flush();
+    }
+
+    private function isUserInvolved(User $user, Transfer $transfer): bool
+    {
+        $userId = $user->getId();
+
+        return $transfer->getPayer()->getId() === $userId
+            || $transfer->getPayee()->getId() === $userId;
+    }
+}

--- a/src/Services/UserDebtService.php
+++ b/src/Services/UserDebtService.php
@@ -20,6 +20,14 @@ class UserDebtService
             $debtAmount = bcsub($debtAmount, $expense->getAmount(), 2);
         }
 
+        foreach ($user->getTransfersSent() as $transfer) {
+            $debtAmount = bcsub($debtAmount, $transfer->getAmount(), 2);
+        }
+
+        foreach ($user->getTransfersReceived() as $transfer) {
+            $debtAmount = bcadd($debtAmount, $transfer->getAmount(), 2);
+        }
+
         return $debtAmount;
     }
 

--- a/tests/Api/TransferApiControllerTest.php
+++ b/tests/Api/TransferApiControllerTest.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\Transfer;
+use App\Tests\Support\ApiTestCase;
+use App\Tests\Support\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+
+class TransferApiControllerTest extends ApiTestCase
+{
+    public function testCreateNotLoggedIn(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/transfers');
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testCreateSuccess(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $entityManager->flush();
+
+        $client->loginUser($payer);
+
+        $this->requestJson($client, 'POST', '/api/transfers', [
+            'payerId' => $payer->getId(),
+            'payeeId' => $payee->getId(),
+            'amount' => '25.00',
+            'occurredOn' => '2026-01-01',
+            'description' => 'Cash repayment',
+        ]);
+
+        $this->assertJsonResponseIsSuccessful(201);
+        $this->assertJsonStructure(['id', 'payerId', 'payeeId', 'amount', 'currency', 'occurredOn', 'description']);
+
+        $response = $this->getJsonResponse();
+        $this->assertSame($payer->getId(), $response['payerId']);
+        $this->assertSame($payee->getId(), $response['payeeId']);
+        $this->assertSame('25.00', $response['amount']);
+        $this->assertSame('PLN', $response['currency']);
+        $this->assertSame('Cash repayment', $response['description']);
+        $this->assertStringStartsWith('2026-01-01', $response['occurredOn']);
+
+        $entityManager->clear();
+
+        /** @var Transfer|null $transfer */
+        $transfer = $entityManager->getRepository(Transfer::class)->find($response['id']);
+
+        $this->assertInstanceOf(Transfer::class, $transfer);
+        $this->assertSame($payer->getId(), $transfer->getPayer()->getId());
+        $this->assertSame($payee->getId(), $transfer->getPayee()->getId());
+        $this->assertSame('25.00', $transfer->getAmount());
+        $this->assertSame('2026-01-01', $transfer->getOccurredOn()->format('Y-m-d'));
+    }
+
+    public function testCreateSuccessWhenNoDescription(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $entityManager->flush();
+
+        $client->loginUser($payer);
+
+        $this->requestJson($client, 'POST', '/api/transfers', [
+            'payerId' => $payer->getId(),
+            'payeeId' => $payee->getId(),
+            'amount' => '25.00',
+            'occurredOn' => '2026-01-01',
+        ]);
+
+        $this->assertJsonResponseIsSuccessful(201);
+
+        $response = $this->getJsonResponse();
+        $this->assertNull($response['description']);
+    }
+
+    public function testCreateFailsWhenPayerEqualsPayee(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $user = UserFactory::createUser();
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        $client->loginUser($user);
+
+        $this->requestJson($client, 'POST', '/api/transfers', [
+            'payerId' => $user->getId(),
+            'payeeId' => $user->getId(),
+            'amount' => '25.00',
+            'occurredOn' => '2026-01-01',
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testCreateFailsWhenAmountIsNotPositive(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $entityManager->flush();
+
+        $client->loginUser($payer);
+
+        $this->requestJson($client, 'POST', '/api/transfers', [
+            'payerId' => $payer->getId(),
+            'payeeId' => $payee->getId(),
+            'amount' => '0.00',
+            'occurredOn' => '2026-01-01',
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testCreateFailsWhenUserDoesNotExist(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+        $entityManager->flush();
+
+        $client->loginUser($payer);
+
+        $this->requestJson($client, 'POST', '/api/transfers', [
+            'payerId' => $payer->getId(),
+            'payeeId' => 999999,
+            'amount' => '25.00',
+            'occurredOn' => '2026-01-01',
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testCreateFailsWhenCreatorIsNotInvolved(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $creator = UserFactory::createUser();
+        $entityManager->persist($creator);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $entityManager->flush();
+
+        $client->loginUser($creator);
+
+        $this->requestJson($client, 'POST', '/api/transfers', [
+            'payerId' => $payer->getId(),
+            'payeeId' => $payee->getId(),
+            'amount' => '25.00',
+            'occurredOn' => '2026-01-01',
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testUpdateSuccess(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $transfer = new Transfer($payer, $payee, '25.00', new \DateTimeImmutable('2026-01-01'), 'Cash');
+        $entityManager->persist($transfer);
+
+        $entityManager->flush();
+        $transferId = $transfer->getId();
+        $payerId = $payer->getId();
+        $payeeId = $payee->getId();
+
+        $client->loginUser($payee);
+
+        $this->requestJson($client, 'PUT', sprintf('/api/transfers/%d', $transferId), [
+            'amount' => '30.00',
+            'occurredOn' => '2026-02-02',
+            'description' => 'Bank transfer',
+        ]);
+
+        $this->assertJsonResponseIsSuccessful(200);
+
+        $response = $this->getJsonResponse();
+        $this->assertSame('30.00', $response['amount']);
+        $this->assertSame('Bank transfer', $response['description']);
+        $this->assertStringStartsWith('2026-02-02', $response['occurredOn']);
+        // Parties are not changeable through update.
+        $this->assertSame($payerId, $response['payerId']);
+        $this->assertSame($payeeId, $response['payeeId']);
+
+        $entityManager->clear();
+
+        /** @var Transfer|null $updated */
+        $updated = $entityManager->getRepository(Transfer::class)->find($transferId);
+        $this->assertInstanceOf(Transfer::class, $updated);
+        $this->assertSame('30.00', $updated->getAmount());
+        $this->assertSame('2026-02-02', $updated->getOccurredOn()->format('Y-m-d'));
+    }
+
+    public function testUpdateForbiddenWhenNotInvolved(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $outsider = UserFactory::createUser();
+        $entityManager->persist($outsider);
+
+        $transfer = new Transfer($payer, $payee, '25.00', new \DateTimeImmutable('2026-01-01'));
+        $entityManager->persist($transfer);
+
+        $entityManager->flush();
+        $transferId = $transfer->getId();
+
+        $client->loginUser($outsider);
+
+        $this->requestJson($client, 'PUT', sprintf('/api/transfers/%d', $transferId), [
+            'amount' => '30.00',
+            'occurredOn' => '2026-02-02',
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testUpdateNotFound(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $user = UserFactory::createUser();
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        $client->loginUser($user);
+
+        $this->requestJson($client, 'PUT', '/api/transfers/999999', [
+            'amount' => '30.00',
+            'occurredOn' => '2026-02-02',
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testDeleteSuccess(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $transfer = new Transfer($payer, $payee, '25.00', new \DateTimeImmutable('2026-01-01'));
+        $entityManager->persist($transfer);
+
+        $entityManager->flush();
+        $transferId = $transfer->getId();
+
+        $client->loginUser($payer);
+
+        $client->request('DELETE', sprintf('/api/transfers/%d', $transferId));
+
+        $this->assertResponseStatusCodeSame(204);
+
+        $entityManager->clear();
+        $this->assertNull($entityManager->getRepository(Transfer::class)->find($transferId));
+    }
+
+    public function testDeleteForbiddenWhenNotInvolved(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payer = UserFactory::createUser();
+        $entityManager->persist($payer);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $outsider = UserFactory::createUser();
+        $entityManager->persist($outsider);
+
+        $transfer = new Transfer($payer, $payee, '25.00', new \DateTimeImmutable('2026-01-01'));
+        $entityManager->persist($transfer);
+
+        $entityManager->flush();
+        $transferId = $transfer->getId();
+
+        $client->loginUser($outsider);
+
+        $client->request('DELETE', sprintf('/api/transfers/%d', $transferId));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testDeleteNotFound(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $user = UserFactory::createUser();
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        $client->loginUser($user);
+
+        $client->request('DELETE', '/api/transfers/999999');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Unit/Entity/TransferTest.php
+++ b/tests/Unit/Entity/TransferTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Transfer;
+use App\Tests\Support\Factory\UserFactory;
+use PHPUnit\Framework\TestCase;
+
+class TransferTest extends TestCase
+{
+    private function makeTransfer(string $currency = 'PLN'): Transfer
+    {
+        return new Transfer(
+            UserFactory::createUser(),
+            UserFactory::createUser(),
+            '10.00',
+            new \DateTimeImmutable(),
+            null,
+            $currency,
+        );
+    }
+
+    public function testConstructorNormalizesAmountToTwoDecimals(): void
+    {
+        $transfer = new Transfer(
+            UserFactory::createUser(),
+            UserFactory::createUser(),
+            '10',
+            new \DateTimeImmutable(),
+        );
+
+        $this->assertSame('10.00', $transfer->getAmount());
+
+        $transfer->setAmount('5.1');
+        $this->assertSame('5.10', $transfer->getAmount());
+    }
+
+    public function testConstructorRejectsSamePayerAndPayee(): void
+    {
+        $user = UserFactory::createUser();
+
+        $this->expectException(\InvalidArgumentException::class);
+        new Transfer($user, $user, '10.00', new \DateTimeImmutable());
+    }
+
+    public function testConstructorDefaultsToPlnCurrency(): void
+    {
+        $transfer = new Transfer(
+            UserFactory::createUser(),
+            UserFactory::createUser(),
+            '10.00',
+            new \DateTimeImmutable(),
+        );
+
+        $this->assertSame('PLN', $transfer->getCurrency());
+    }
+
+    public function testSetCurrencyAcceptsValidIsoCodes(): void
+    {
+        $transfer = $this->makeTransfer();
+
+        foreach (['PLN', 'USD', 'EUR', 'GBP'] as $code) {
+            $transfer->setCurrency($code);
+            $this->assertSame($code, $transfer->getCurrency());
+        }
+    }
+
+    /**
+     * @dataProvider invalidCurrencyProvider
+     */
+    public function testSetCurrencyRejectsInvalidCodes(string $invalid): void
+    {
+        $transfer = $this->makeTransfer();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $transfer->setCurrency($invalid);
+    }
+
+    /**
+     * @dataProvider invalidCurrencyProvider
+     */
+    public function testConstructorRejectsInvalidCurrencyCodes(string $invalid): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->makeTransfer($invalid);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidCurrencyProvider(): array
+    {
+        return [
+            'lowercase' => ['pln'],
+            'mixed case' => ['Pln'],
+            'too short' => ['PL'],
+            'too long' => ['PLNN'],
+            'numeric' => ['123'],
+            'empty string' => [''],
+        ];
+    }
+}

--- a/tests/Unit/Services/UserDebtServiceTest.php
+++ b/tests/Unit/Services/UserDebtServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Services;
 
 use App\Entity\Debt;
 use App\Entity\Expense;
+use App\Entity\Transfer;
 use App\Entity\User;
 use App\Services\UserDebtService;
 use App\Tests\Support\Factory\UserFactory;
@@ -156,6 +157,40 @@ class UserDebtServiceTest extends TestCase
 
         $balance = $this->service->calculateExpenseBalanceForUser($expense, $users[$targetUserKey]);
         $this->assertEquals($expectedBalance, $balance);
+    }
+
+    public function testTransfersAdjustUserDebtAmount(): void
+    {
+        $payer = UserFactory::createUser();
+        $payee = UserFactory::createUser();
+
+        $transfer = new Transfer($payer, $payee, '10.00', new \DateTimeImmutable('2026-01-01'));
+        $payer->addTransferSent($transfer);
+        $payee->addTransferReceived($transfer);
+
+        // Paying reduces what the payer owes; being paid reduces what the payee is owed.
+        $this->assertEquals('-10.00', $this->service->getUserDebtAmount($payer));
+        $this->assertEquals('10.00', $this->service->getUserDebtAmount($payee));
+    }
+
+    public function testTransferSettlesDebtToZero(): void
+    {
+        $debtor = UserFactory::createUser();
+        $creditor = UserFactory::createUser();
+
+        $expense = new Expense($creditor, 'Dinner', '', '10.00', new \DateTimeImmutable('2026-01-01'));
+        $creditor->addExpense($expense);
+        $debtor->addDebt(new Debt($debtor, $expense, '10.00'));
+
+        $this->assertEquals('10.00', $this->service->getUserDebtAmount($debtor));
+        $this->assertEquals('-10.00', $this->service->getUserDebtAmount($creditor));
+
+        $transfer = new Transfer($debtor, $creditor, '10.00', new \DateTimeImmutable('2026-01-02'));
+        $debtor->addTransferSent($transfer);
+        $creditor->addTransferReceived($transfer);
+
+        $this->assertEquals('0.00', $this->service->getUserDebtAmount($debtor));
+        $this->assertEquals('0.00', $this->service->getUserDebtAmount($creditor));
     }
 
     private function addDebtToUser(User $user, string $amount): void


### PR DESCRIPTION
- Add Transfer entity + migration (transfer table, FKs to user)
- POST/PUT/DELETE /api/transfers (update edits amount/date/description only, not parties)
- Net transfers into UserDebtService::getUserDebtAmount()
- Unit + API tests; PHPStan/CS/PHPUnit green