### PR TITLE
feat: add split modifiers (percentage, shares, exact, equal)

### DIFF
--- a/migrations/Version20260619230828.php
+++ b/migrations/Version20260619230828.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260619230828 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add split_type to expense and split_value to debt';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE expense ADD split_type VARCHAR(16) NOT NULL DEFAULT \'exact\'');
+        $this->addSql('ALTER TABLE debt ADD split_value DECIMAL(10, 2) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE expense DROP COLUMN split_type');
+        $this->addSql('ALTER TABLE debt DROP COLUMN split_value');
+    }
+}

--- a/src/Controller/Api/ExpenseApiController.php
+++ b/src/Controller/Api/ExpenseApiController.php
@@ -73,15 +73,26 @@ class ExpenseApiController extends AbstractController
 
         $expense = $this->expenseCreateService->create($user, $request);
 
-        return $this->json(new ExpenseResponse(
-            id: $expense->getId(),
-            title: $expense->getTitle(),
-            description: $expense->getDescription(),
-            amount: $expense->getAmount(),
-            currency: $expense->getCurrency(),
-            payeeId: $expense->getPayee()->getId(),
-            occurredOn: $expense->getOccurredOn(),
-        ), JsonResponse::HTTP_CREATED);
+        return $this->json(ExpenseResponse::fromExpense($expense), JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/expenses/{id}', name: 'api_expenses_show', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function show(int $id): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $expense = $this->expenseRepository->findOneByIdWithDebts($id);
+        if (null === $expense) {
+            throw $this->createNotFoundException('Expense not found.');
+        }
+
+        if (!$this->isUserInvolved($user, $expense)) {
+            throw $this->createAccessDeniedException('You are not involved in this expense.');
+        }
+
+        return $this->json(ExpenseResponse::fromExpense($expense));
     }
 
     #[Route('/expenses/{id}', name: 'api_expenses_update', methods: ['PUT'])]
@@ -101,14 +112,21 @@ class ExpenseApiController extends AbstractController
 
         $expense = $this->expenseUpdateService->update($user, $expense, $request);
 
-        return $this->json(new ExpenseResponse(
-            id: $expense->getId(),
-            title: $expense->getTitle(),
-            description: $expense->getDescription(),
-            amount: $expense->getAmount(),
-            currency: $expense->getCurrency(),
-            payeeId: $expense->getPayee()->getId(),
-            occurredOn: $expense->getOccurredOn(),
-        ));
+        return $this->json(ExpenseResponse::fromExpense($expense));
+    }
+
+    private function isUserInvolved(User $user, Expense $expense): bool
+    {
+        if ($expense->getPayee()->getId() === $user->getId()) {
+            return true;
+        }
+
+        foreach ($expense->getDebts() as $debt) {
+            if ($debt->getPayer()->getId() === $user->getId()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Dto/ExpenseDebtRequest.php
+++ b/src/Dto/ExpenseDebtRequest.php
@@ -15,7 +15,7 @@ readonly class ExpenseDebtRequest
 
         #[Assert\Positive]
         #[Decimal(scale: 2)]
-        public string $amount,
+        public ?string $value = null,
     ) {
     }
 }

--- a/src/Dto/ExpenseDebtResponse.php
+++ b/src/Dto/ExpenseDebtResponse.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+readonly class ExpenseDebtResponse
+{
+    public function __construct(
+        public int $payerId,
+        public string $amount,
+        public ?string $splitValue,
+    ) {
+    }
+}

--- a/src/Dto/ExpenseRequest.php
+++ b/src/Dto/ExpenseRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Dto;
 
+use App\Enum\SplitType;
 use App\Validator\Constraints\Decimal;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -33,6 +34,8 @@ readonly class ExpenseRequest
         public array $debts,
 
         public \DateTimeImmutable $occurredOn,
+
+        public SplitType $splitType = SplitType::Exact,
 
         public ?string $description = null,
     ) {

--- a/src/Dto/ExpenseResponse.php
+++ b/src/Dto/ExpenseResponse.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace App\Dto;
 
+use App\Entity\Expense;
+use App\Enum\SplitType;
+
 readonly class ExpenseResponse
 {
+    /**
+     * @param list<ExpenseDebtResponse> $debts
+     */
     public function __construct(
         public int $id,
         public string $title,
@@ -14,6 +20,32 @@ readonly class ExpenseResponse
         public string $currency,
         public int $payeeId,
         public \DateTimeImmutable $occurredOn,
+        public SplitType $splitType,
+        public array $debts,
     ) {
+    }
+
+    public static function fromExpense(Expense $expense): self
+    {
+        $debts = array_map(
+            fn ($debt) => new ExpenseDebtResponse(
+                payerId: $debt->getPayer()->getId(),
+                amount: $debt->getAmount(),
+                splitValue: $debt->getSplitValue(),
+            ),
+            $expense->getDebts()->toArray()
+        );
+
+        return new self(
+            id: $expense->getId(),
+            title: $expense->getTitle(),
+            description: $expense->getDescription(),
+            amount: $expense->getAmount(),
+            currency: $expense->getCurrency(),
+            payeeId: $expense->getPayee()->getId(),
+            occurredOn: $expense->getOccurredOn(),
+            splitType: $expense->getSplitType(),
+            debts: array_values($debts),
+        );
     }
 }

--- a/src/Entity/Debt.php
+++ b/src/Entity/Debt.php
@@ -24,6 +24,9 @@ class Debt
     #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2)]
     private string $amount;
 
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2, nullable: true)]
+    private ?string $splitValue = null;
+
     #[ORM\Column(length: 3)]
     private string $currency;
 
@@ -37,12 +40,13 @@ class Debt
     #[ORM\Column]
     private \DateTimeImmutable $updatedAt;
 
-    public function __construct(User $user, Expense $expense, string $amount, string $currency = 'PLN')
+    public function __construct(User $user, Expense $expense, string $amount, string $currency = 'PLN', ?string $splitValue = null)
     {
         $this->payer = $user;
         $this->expense = $expense;
         $this->setAmount($amount);
         $this->setCurrency($currency);
+        $this->setSplitValue($splitValue);
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
     }
@@ -65,6 +69,18 @@ class Debt
     public function setAmount(string $amount): static
     {
         $this->amount = bcadd($amount, '0', 2);
+
+        return $this;
+    }
+
+    public function getSplitValue(): ?string
+    {
+        return $this->splitValue;
+    }
+
+    public function setSplitValue(?string $splitValue): static
+    {
+        $this->splitValue = null === $splitValue ? null : bcadd($splitValue, '0', 2);
 
         return $this;
     }

--- a/src/Entity/Expense.php
+++ b/src/Entity/Expense.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Enum\SplitType;
 use App\Repository\ExpenseRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -35,6 +36,9 @@ class Expense
     #[ORM\Column(length: 3)]
     private string $currency;
 
+    #[ORM\Column(length: 16, enumType: SplitType::class)]
+    private SplitType $splitType;
+
     #[ORM\Column(type: Types::DATE_IMMUTABLE)]
     private \DateTimeImmutable $occurredOn;
 
@@ -50,7 +54,7 @@ class Expense
     #[ORM\OneToMany(targetEntity: Debt::class, mappedBy: 'expense', orphanRemoval: true)]
     private Collection $debts;
 
-    public function __construct(User $payee, string $title, ?string $description, string $amount, \DateTimeImmutable $occurredOn, string $currency = 'PLN')
+    public function __construct(User $payee, string $title, ?string $description, string $amount, \DateTimeImmutable $occurredOn, string $currency = 'PLN', SplitType $splitType = SplitType::Exact)
     {
         $this->payee = $payee;
         $this->title = $title;
@@ -60,6 +64,7 @@ class Expense
 
         $this->occurredOn = $occurredOn;
         $this->setCurrency($currency);
+        $this->splitType = $splitType;
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
         $this->debts = new ArrayCollection();
@@ -142,6 +147,18 @@ class Expense
         }
 
         $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getSplitType(): SplitType
+    {
+        return $this->splitType;
+    }
+
+    public function setSplitType(SplitType $splitType): static
+    {
+        $this->splitType = $splitType;
 
         return $this;
     }

--- a/src/Enum/SplitType.php
+++ b/src/Enum/SplitType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum SplitType: string
+{
+    case Exact = 'exact';
+    case Percentage = 'percentage';
+    case Shares = 'shares';
+    case Equal = 'equal';
+}

--- a/src/Services/ExpenseCreateService.php
+++ b/src/Services/ExpenseCreateService.php
@@ -10,7 +10,6 @@ use App\Entity\Expense;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class ExpenseCreateService
@@ -18,6 +17,7 @@ class ExpenseCreateService
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly EntityManagerInterface $entityManager,
+        private readonly SplitCalculator $splitCalculator,
     ) {
     }
 
@@ -39,29 +39,23 @@ class ExpenseCreateService
             throw new UnprocessableEntityHttpException('Creator must be the payee or one of the debtors.');
         }
 
+        foreach ($request->debts as $debtRequest) {
+            if (!isset($usersById[$debtRequest->payerId])) {
+                throw new UnprocessableEntityHttpException('One or more debt users do not exist.');
+            }
+        }
+
         $payee = $usersById[$request->payeeId];
-        $expense = new Expense($payee, $request->title, $request->description, $request->amount, $request->occurredOn);
+        $expense = new Expense($payee, $request->title, $request->description, $request->amount, $request->occurredOn, splitType: $request->splitType);
 
         $this->entityManager->persist($expense);
 
-        $debtsTotal = '0.00';
+        $splits = $this->splitCalculator->calculate($request->splitType, $request->amount, $request->debts);
 
-        foreach ($request->debts as $debtRequest) {
-            $payer = $usersById[$debtRequest->payerId] ?? null;
-            if (null === $payer) {
-                throw new UnprocessableEntityHttpException('One or more debt users do not exist.');
-            }
-
-            $debt = new Debt($payer, $expense, $debtRequest->amount, $expense->getCurrency());
+        foreach ($splits as $split) {
+            $debt = new Debt($usersById[$split['payerId']], $expense, $split['amount'], $expense->getCurrency(), $split['splitValue']);
             $expense->addDebt($debt);
-
             $this->entityManager->persist($debt);
-
-            $debtsTotal = bcadd($debtsTotal, $debtRequest->amount, 2);
-        }
-
-        if (0 !== bccomp($debtsTotal, $request->amount, 2)) {
-            throw new BadRequestHttpException('Debts amount sum must be equal to expense amount.');
         }
 
         $this->entityManager->flush();

--- a/src/Services/ExpenseUpdateService.php
+++ b/src/Services/ExpenseUpdateService.php
@@ -11,7 +11,6 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class ExpenseUpdateService
@@ -19,6 +18,7 @@ class ExpenseUpdateService
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly EntityManagerInterface $entityManager,
+        private readonly SplitCalculator $splitCalculator,
     ) {
     }
 
@@ -44,18 +44,13 @@ class ExpenseUpdateService
             throw new UnprocessableEntityHttpException('Payee user does not exist.');
         }
 
-        $debtsTotal = '0.00';
         foreach ($request->debts as $debtRequest) {
             if (!isset($usersById[$debtRequest->payerId])) {
                 throw new UnprocessableEntityHttpException('One or more debt users do not exist.');
             }
-
-            $debtsTotal = bcadd($debtsTotal, $debtRequest->amount, 2);
         }
 
-        if (0 !== bccomp($debtsTotal, $request->amount, 2)) {
-            throw new BadRequestHttpException('Debts amount sum must be equal to expense amount.');
-        }
+        $splits = $this->splitCalculator->calculate($request->splitType, $request->amount, $request->debts);
 
         $existingDebts = $this->entityManager->getRepository(Debt::class)->findBy(['expense' => $expense]);
         foreach ($existingDebts as $debt) {
@@ -68,10 +63,11 @@ class ExpenseUpdateService
             ->setTitle($request->title)
             ->setDescription($request->description)
             ->setAmount($request->amount)
-            ->setOccurredOn($request->occurredOn);
+            ->setOccurredOn($request->occurredOn)
+            ->setSplitType($request->splitType);
 
-        foreach ($request->debts as $debtRequest) {
-            $debt = new Debt($usersById[$debtRequest->payerId], $expense, $debtRequest->amount, $expense->getCurrency());
+        foreach ($splits as $split) {
+            $debt = new Debt($usersById[$split['payerId']], $expense, $split['amount'], $expense->getCurrency(), $split['splitValue']);
             $expense->addDebt($debt);
             $this->entityManager->persist($debt);
         }

--- a/src/Services/SplitCalculator.php
+++ b/src/Services/SplitCalculator.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Dto\ExpenseDebtRequest;
+use App\Enum\SplitType;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class SplitCalculator
+{
+    /**
+     * Resolves a split request into the final per-debtor amounts and the modifier
+     * value to persist for each debtor.
+     *
+     * @param list<ExpenseDebtRequest> $debts
+     *
+     * @return list<array{payerId: int, amount: string, splitValue: ?string}>
+     */
+    public function calculate(SplitType $splitType, string $total, array $debts): array
+    {
+        return match ($splitType) {
+            SplitType::Exact => $this->exact($total, $debts),
+            SplitType::Percentage => $this->percentage($total, $debts),
+            SplitType::Shares => $this->shares($total, $debts),
+            SplitType::Equal => $this->equal($total, $debts),
+        };
+    }
+
+    /**
+     * @param list<ExpenseDebtRequest> $debts
+     *
+     * @return list<array{payerId: int, amount: string, splitValue: ?string}>
+     */
+    private function exact(string $total, array $debts): array
+    {
+        $result = [];
+        $sum = '0.00';
+        foreach ($debts as $debt) {
+            $value = $this->requireValue($debt);
+            $sum = bcadd($sum, $value, 2);
+            $result[] = ['payerId' => $debt->payerId, 'amount' => bcadd($value, '0', 2), 'splitValue' => null];
+        }
+
+        if (0 !== bccomp($sum, $total, 2)) {
+            throw new BadRequestHttpException('Debts amount sum must be equal to expense amount.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<ExpenseDebtRequest> $debts
+     *
+     * @return list<array{payerId: int, amount: string, splitValue: ?string}>
+     */
+    private function percentage(string $total, array $debts): array
+    {
+        $weights = [];
+        $percentTotal = '0.00';
+        foreach ($debts as $debt) {
+            $value = $this->requireValue($debt);
+            $weights[] = $value;
+            $percentTotal = bcadd($percentTotal, $value, 2);
+        }
+
+        if (0 !== bccomp($percentTotal, '100', 2)) {
+            throw new BadRequestHttpException('Split percentages must total 100.');
+        }
+
+        return $this->assign($total, $debts, $weights, true);
+    }
+
+    /**
+     * @param list<ExpenseDebtRequest> $debts
+     *
+     * @return list<array{payerId: int, amount: string, splitValue: ?string}>
+     */
+    private function shares(string $total, array $debts): array
+    {
+        $weights = [];
+        foreach ($debts as $debt) {
+            $weights[] = $this->requireValue($debt);
+        }
+
+        return $this->assign($total, $debts, $weights, true);
+    }
+
+    /**
+     * @param list<ExpenseDebtRequest> $debts
+     *
+     * @return list<array{payerId: int, amount: string, splitValue: ?string}>
+     */
+    private function equal(string $total, array $debts): array
+    {
+        $weights = array_fill(0, count($debts), '1');
+
+        return $this->assign($total, $debts, $weights, false);
+    }
+
+    /**
+     * Distributes the total across debtors proportionally to their weights using the
+     * largest-remainder method, so the per-cent amounts always sum back to the total.
+     *
+     * @param list<ExpenseDebtRequest> $debts
+     * @param list<string>             $weights
+     *
+     * @return list<array{payerId: int, amount: string, splitValue: ?string}>
+     */
+    private function assign(string $total, array $debts, array $weights, bool $storeWeight): array
+    {
+        $weightTotal = '0';
+        foreach ($weights as $weight) {
+            $weightTotal = bcadd($weightTotal, $weight, 6);
+        }
+
+        if (0 === bccomp($weightTotal, '0', 6)) {
+            throw new BadRequestHttpException('Split weights must be greater than zero.');
+        }
+
+        $totalCents = bcmul($total, '100', 0);
+
+        $floors = [];
+        $remainders = [];
+        $assignedCents = '0';
+        foreach ($weights as $index => $weight) {
+            $ideal = bcdiv(bcmul((string) $totalCents, $weight, 6), $weightTotal, 6);
+            $floor = bcdiv($ideal, '1', 0);
+            $floors[$index] = $floor;
+            $remainders[$index] = bcsub($ideal, $floor, 6);
+            $assignedCents = bcadd($assignedCents, $floor, 0);
+        }
+
+        $leftover = (int) bcsub((string) $totalCents, $assignedCents, 0);
+
+        $order = array_keys($remainders);
+        usort($order, fn ($a, $b) => bccomp($remainders[$b], $remainders[$a], 6));
+        for ($position = 0; $position < $leftover; ++$position) {
+            $floors[$order[$position]] = bcadd($floors[$order[$position]], '1', 0);
+        }
+
+        $result = [];
+        foreach ($debts as $index => $debt) {
+            $result[] = [
+                'payerId' => $debt->payerId,
+                'amount' => bcdiv($floors[$index], '100', 2),
+                'splitValue' => $storeWeight ? bcadd($weights[$index], '0', 2) : null,
+            ];
+        }
+
+        return $result;
+    }
+
+    private function requireValue(ExpenseDebtRequest $debt): string
+    {
+        if (null === $debt->value) {
+            throw new BadRequestHttpException('A split value is required for each debtor.');
+        }
+
+        return $debt->value;
+    }
+}

--- a/tests/Api/ExpenseApiControllerTest.php
+++ b/tests/Api/ExpenseApiControllerTest.php
@@ -43,8 +43,8 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $creator->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $otherUser->getId(), 'amount' => '70.00'],
-                ['payerId' => $creator->getId(), 'amount' => '30.00'],
+                ['payerId' => $otherUser->getId(), 'value' => '70.00'],
+                ['payerId' => $creator->getId(), 'value' => '30.00'],
             ],
         ]);
 
@@ -58,6 +58,9 @@ class ExpenseApiControllerTest extends ApiTestCase
         $this->assertSame('PLN', $response['currency']);
         $this->assertSame($creator->getId(), $response['payeeId']);
         $this->assertStringStartsWith('2026-01-01', $response['occurredOn']);
+        $this->assertSame('exact', $response['splitType']);
+        $this->assertCount(2, $response['debts']);
+        $this->assertJsonStructure([0 => ['payerId', 'amount', 'splitValue']], $response['debts']);
 
         $entityManager->clear();
         $expenseRepository = $entityManager->getRepository(Expense::class);
@@ -107,7 +110,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $creator->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $creator->getId(), 'amount' => '100.00'],
+                ['payerId' => $creator->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -140,8 +143,8 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $creator->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $otherUser->getId(), 'amount' => '60.00'],
-                ['payerId' => $creator->getId(), 'amount' => '30.00'],
+                ['payerId' => $otherUser->getId(), 'value' => '60.00'],
+                ['payerId' => $creator->getId(), 'value' => '30.00'],
             ],
         ]);
 
@@ -167,7 +170,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => 999999,
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $creator->getId(), 'amount' => '100.00'],
+                ['payerId' => $creator->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -200,7 +203,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $payee->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $debtor->getId(), 'amount' => '100.00'],
+                ['payerId' => $debtor->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -226,7 +229,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $creator->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $creator->getId(), 'amount' => '-1.00'],
+                ['payerId' => $creator->getId(), 'value' => '-1.00'],
             ],
         ]);
 
@@ -273,8 +276,8 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $otherUser->getId(),
             'occurredOn' => '2026-01-15',
             'debts' => [
-                ['payerId' => $editor->getId(), 'amount' => '60.00'],
-                ['payerId' => $newPayer->getId(), 'amount' => '60.00'],
+                ['payerId' => $editor->getId(), 'value' => '60.00'],
+                ['payerId' => $newPayer->getId(), 'value' => '60.00'],
             ],
         ]);
 
@@ -336,7 +339,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $editor->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $editor->getId(), 'amount' => '100.00'],
+                ['payerId' => $editor->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -365,7 +368,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $user->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $user->getId(), 'amount' => '100.00'],
+                ['payerId' => $user->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -402,7 +405,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $payee->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $debtor->getId(), 'amount' => '100.00'],
+                ['payerId' => $debtor->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -433,7 +436,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $editor->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => 999999, 'amount' => '100.00'],
+                ['payerId' => 999999, 'value' => '100.00'],
             ],
         ]);
 
@@ -467,8 +470,8 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $editor->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $editor->getId(), 'amount' => '40.00'],
-                ['payerId' => $otherUser->getId(), 'amount' => '40.00'],
+                ['payerId' => $editor->getId(), 'value' => '40.00'],
+                ['payerId' => $otherUser->getId(), 'value' => '40.00'],
             ],
         ]);
 
@@ -505,7 +508,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => $payee->getId(),
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $debtor->getId(), 'amount' => '100.00'],
+                ['payerId' => $debtor->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -536,7 +539,7 @@ class ExpenseApiControllerTest extends ApiTestCase
             'payeeId' => 999999,
             'occurredOn' => '2026-01-01',
             'debts' => [
-                ['payerId' => $editor->getId(), 'amount' => '100.00'],
+                ['payerId' => $editor->getId(), 'value' => '100.00'],
             ],
         ]);
 
@@ -669,5 +672,259 @@ class ExpenseApiControllerTest extends ApiTestCase
         $this->assertSame('PLN', $response[0]['currency']);
         $this->assertSame('100.00', $response[0]['value']);
         $this->assertStringStartsWith('2026-01-01', $response[0]['occurredOn']);
+    }
+
+    public function testCreateWithPercentageSplit(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $creator = UserFactory::createUser();
+        $entityManager->persist($creator);
+
+        $otherUser = UserFactory::createUser();
+        $entityManager->persist($otherUser);
+
+        $entityManager->flush();
+
+        $client->loginUser($creator);
+
+        $this->requestJson($client, 'POST', '/api/expenses', [
+            'title' => 'Dinner',
+            'amount' => '100.00',
+            'payeeId' => $creator->getId(),
+            'occurredOn' => '2026-01-01',
+            'splitType' => 'percentage',
+            'debts' => [
+                ['payerId' => $creator->getId(), 'value' => '30.00'],
+                ['payerId' => $otherUser->getId(), 'value' => '70.00'],
+            ],
+        ]);
+
+        $this->assertJsonResponseIsSuccessful(201);
+
+        $response = $this->getJsonResponse();
+        $this->assertSame('percentage', $response['splitType']);
+
+        $byPayer = $this->indexDebtsByPayer($response['debts']);
+        $this->assertSame(['amount' => '30.00', 'splitValue' => '30.00'], $byPayer[$creator->getId()]);
+        $this->assertSame(['amount' => '70.00', 'splitValue' => '70.00'], $byPayer[$otherUser->getId()]);
+    }
+
+    public function testCreateWithPercentageSplitFailsWhenNotHundred(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $creator = UserFactory::createUser();
+        $entityManager->persist($creator);
+
+        $otherUser = UserFactory::createUser();
+        $entityManager->persist($otherUser);
+
+        $entityManager->flush();
+
+        $client->loginUser($creator);
+
+        $this->requestJson($client, 'POST', '/api/expenses', [
+            'title' => 'Dinner',
+            'amount' => '100.00',
+            'payeeId' => $creator->getId(),
+            'occurredOn' => '2026-01-01',
+            'splitType' => 'percentage',
+            'debts' => [
+                ['payerId' => $creator->getId(), 'value' => '30.00'],
+                ['payerId' => $otherUser->getId(), 'value' => '60.00'],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testCreateWithSharesSplitDistributesRemainder(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $creator = UserFactory::createUser();
+        $entityManager->persist($creator);
+
+        $second = UserFactory::createUser();
+        $entityManager->persist($second);
+
+        $third = UserFactory::createUser();
+        $entityManager->persist($third);
+
+        $entityManager->flush();
+
+        $client->loginUser($creator);
+
+        $this->requestJson($client, 'POST', '/api/expenses', [
+            'title' => 'Dinner',
+            'amount' => '10.00',
+            'payeeId' => $creator->getId(),
+            'occurredOn' => '2026-01-01',
+            'splitType' => 'shares',
+            'debts' => [
+                ['payerId' => $creator->getId(), 'value' => '1'],
+                ['payerId' => $second->getId(), 'value' => '1'],
+                ['payerId' => $third->getId(), 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertJsonResponseIsSuccessful(201);
+
+        $response = $this->getJsonResponse();
+        $this->assertSame('shares', $response['splitType']);
+
+        $amounts = array_map(fn ($debt) => $debt['amount'], $response['debts']);
+        sort($amounts);
+        $this->assertSame(['3.33', '3.33', '3.34'], $amounts);
+
+        $sum = array_reduce($response['debts'], fn ($carry, $debt) => bcadd($carry, $debt['amount'], 2), '0.00');
+        $this->assertSame('10.00', $sum);
+    }
+
+    public function testCreateWithEqualSplitStoresNoSplitValue(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $creator = UserFactory::createUser();
+        $entityManager->persist($creator);
+
+        $second = UserFactory::createUser();
+        $entityManager->persist($second);
+
+        $third = UserFactory::createUser();
+        $entityManager->persist($third);
+
+        $entityManager->flush();
+
+        $client->loginUser($creator);
+
+        $this->requestJson($client, 'POST', '/api/expenses', [
+            'title' => 'Dinner',
+            'amount' => '10.00',
+            'payeeId' => $creator->getId(),
+            'occurredOn' => '2026-01-01',
+            'splitType' => 'equal',
+            'debts' => [
+                ['payerId' => $creator->getId()],
+                ['payerId' => $second->getId()],
+                ['payerId' => $third->getId()],
+            ],
+        ]);
+
+        $this->assertJsonResponseIsSuccessful(201);
+
+        $response = $this->getJsonResponse();
+        $this->assertSame('equal', $response['splitType']);
+
+        foreach ($response['debts'] as $debt) {
+            $this->assertNull($debt['splitValue']);
+        }
+
+        $amounts = array_map(fn ($debt) => $debt['amount'], $response['debts']);
+        sort($amounts);
+        $this->assertSame(['3.33', '3.33', '3.34'], $amounts);
+    }
+
+    public function testShowReturnsExpenseWithDebts(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $debtor = UserFactory::createUser();
+        $entityManager->persist($debtor);
+
+        $expense = new Expense($payee, 'Dinner', 'Friday dinner', '100.00', new \DateTimeImmutable('2026-01-01'));
+        $entityManager->persist($expense);
+        $debt = new Debt($debtor, $expense, '100.00');
+        $expense->addDebt($debt);
+        $entityManager->persist($debt);
+
+        $entityManager->flush();
+
+        $client->loginUser($payee);
+        $client->request('GET', sprintf('/api/expenses/%d', $expense->getId()));
+
+        $this->assertJsonResponseIsSuccessful(200);
+        $this->assertJsonStructure([
+            'id', 'title', 'description', 'amount', 'currency', 'payeeId', 'occurredOn', 'splitType',
+            'debts' => [0 => ['payerId', 'amount', 'splitValue']],
+        ]);
+
+        $response = $this->getJsonResponse();
+        $this->assertSame('Dinner', $response['title']);
+        $this->assertSame('exact', $response['splitType']);
+        $this->assertCount(1, $response['debts']);
+        $this->assertSame($debtor->getId(), $response['debts'][0]['payerId']);
+    }
+
+    public function testShowFailsWhenExpenseDoesNotExist(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $user = UserFactory::createUser();
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        $client->loginUser($user);
+        $client->request('GET', '/api/expenses/999999');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testShowFailsWhenUserIsNotInvolved(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $payee = UserFactory::createUser();
+        $entityManager->persist($payee);
+
+        $debtor = UserFactory::createUser();
+        $entityManager->persist($debtor);
+
+        $outsider = UserFactory::createUser();
+        $entityManager->persist($outsider);
+
+        $expense = new Expense($payee, 'Dinner', 'Friday dinner', '100.00', new \DateTimeImmutable('2026-01-01'));
+        $entityManager->persist($expense);
+        $entityManager->persist(new Debt($debtor, $expense, '100.00'));
+
+        $entityManager->flush();
+
+        $client->loginUser($outsider);
+        $client->request('GET', sprintf('/api/expenses/%d', $expense->getId()));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * @param list<array{payerId: int, amount: string, splitValue: ?string}> $debts
+     *
+     * @return array<int, array{amount: string, splitValue: ?string}>
+     */
+    private function indexDebtsByPayer(array $debts): array
+    {
+        $byPayer = [];
+        foreach ($debts as $debt) {
+            $byPayer[$debt['payerId']] = ['amount' => $debt['amount'], 'splitValue' => $debt['splitValue']];
+        }
+
+        return $byPayer;
     }
 }

--- a/tests/Unit/Entity/DebtTest.php
+++ b/tests/Unit/Entity/DebtTest.php
@@ -25,6 +25,22 @@ class DebtTest extends TestCase
         return new Debt(UserFactory::createUser(), $expense, '10.00', $currency);
     }
 
+    public function testSplitValueDefaultsToNull(): void
+    {
+        $this->assertNull($this->makeDebt()->getSplitValue());
+    }
+
+    public function testSetSplitValueNormalisesToTwoDecimals(): void
+    {
+        $debt = $this->makeDebt();
+        $debt->setSplitValue('2');
+
+        $this->assertSame('2.00', $debt->getSplitValue());
+
+        $debt->setSplitValue(null);
+        $this->assertNull($debt->getSplitValue());
+    }
+
     public function testSetCurrencyAcceptsValidIsoCodes(): void
     {
         $debt = $this->makeDebt();

--- a/tests/Unit/Entity/ExpenseTest.php
+++ b/tests/Unit/Entity/ExpenseTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Debt;
 use App\Entity\Expense;
+use App\Enum\SplitType;
 use App\Tests\Support\Factory\UserFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -79,6 +80,19 @@ class ExpenseTest extends TestCase
             'numeric' => ['123'],
             'empty string' => [''],
         ];
+    }
+
+    public function testConstructorDefaultsToExactSplitType(): void
+    {
+        $this->assertSame(SplitType::Exact, $this->makeExpense()->getSplitType());
+    }
+
+    public function testSetSplitType(): void
+    {
+        $expense = $this->makeExpense();
+        $expense->setSplitType(SplitType::Shares);
+
+        $this->assertSame(SplitType::Shares, $expense->getSplitType());
     }
 
     public function testAddDebtAcceptsMatchingCurrency(): void

--- a/tests/Unit/Services/SplitCalculatorTest.php
+++ b/tests/Unit/Services/SplitCalculatorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Services;
+
+use App\Dto\ExpenseDebtRequest;
+use App\Enum\SplitType;
+use App\Services\SplitCalculator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class SplitCalculatorTest extends TestCase
+{
+    private SplitCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new SplitCalculator();
+        parent::setUp();
+    }
+
+    public function testExactPassesThroughAndStoresNoSplitValue(): void
+    {
+        $result = $this->calculator->calculate(SplitType::Exact, '100.00', [
+            new ExpenseDebtRequest(1, '70.00'),
+            new ExpenseDebtRequest(2, '30.00'),
+        ]);
+
+        $this->assertSame([
+            ['payerId' => 1, 'amount' => '70.00', 'splitValue' => null],
+            ['payerId' => 2, 'amount' => '30.00', 'splitValue' => null],
+        ], $result);
+    }
+
+    public function testExactFailsWhenSumDoesNotMatch(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->calculator->calculate(SplitType::Exact, '100.00', [
+            new ExpenseDebtRequest(1, '70.00'),
+            new ExpenseDebtRequest(2, '20.00'),
+        ]);
+    }
+
+    public function testPercentageComputesAmountsAndStoresPercent(): void
+    {
+        $result = $this->calculator->calculate(SplitType::Percentage, '100.00', [
+            new ExpenseDebtRequest(1, '30.00'),
+            new ExpenseDebtRequest(2, '70.00'),
+        ]);
+
+        $this->assertSame([
+            ['payerId' => 1, 'amount' => '30.00', 'splitValue' => '30.00'],
+            ['payerId' => 2, 'amount' => '70.00', 'splitValue' => '70.00'],
+        ], $result);
+    }
+
+    public function testPercentageFailsWhenNotHundred(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->calculator->calculate(SplitType::Percentage, '100.00', [
+            new ExpenseDebtRequest(1, '30.00'),
+            new ExpenseDebtRequest(2, '60.00'),
+        ]);
+    }
+
+    public function testSharesDistributesRemainderByLargestFraction(): void
+    {
+        $result = $this->calculator->calculate(SplitType::Shares, '10.00', [
+            new ExpenseDebtRequest(1, '1'),
+            new ExpenseDebtRequest(2, '1'),
+            new ExpenseDebtRequest(3, '1'),
+        ]);
+
+        // 10.00 / 3 = 3.3333; leftover cent goes to the first by stable tie-break.
+        $this->assertSame([
+            ['payerId' => 1, 'amount' => '3.34', 'splitValue' => '1.00'],
+            ['payerId' => 2, 'amount' => '3.33', 'splitValue' => '1.00'],
+            ['payerId' => 3, 'amount' => '3.33', 'splitValue' => '1.00'],
+        ], $result);
+
+        $this->assertSame('10.00', $this->sum($result));
+    }
+
+    public function testSharesProportional(): void
+    {
+        $result = $this->calculator->calculate(SplitType::Shares, '90.00', [
+            new ExpenseDebtRequest(1, '1'),
+            new ExpenseDebtRequest(2, '2'),
+        ]);
+
+        $this->assertSame([
+            ['payerId' => 1, 'amount' => '30.00', 'splitValue' => '1.00'],
+            ['payerId' => 2, 'amount' => '60.00', 'splitValue' => '2.00'],
+        ], $result);
+    }
+
+    public function testEqualSplitsEvenlyWithoutSplitValue(): void
+    {
+        $result = $this->calculator->calculate(SplitType::Equal, '10.00', [
+            new ExpenseDebtRequest(1),
+            new ExpenseDebtRequest(2),
+            new ExpenseDebtRequest(3),
+        ]);
+
+        $this->assertSame([
+            ['payerId' => 1, 'amount' => '3.34', 'splitValue' => null],
+            ['payerId' => 2, 'amount' => '3.33', 'splitValue' => null],
+            ['payerId' => 3, 'amount' => '3.33', 'splitValue' => null],
+        ], $result);
+
+        $this->assertSame('10.00', $this->sum($result));
+    }
+
+    public function testPercentageWithRoundingStillSumsToTotal(): void
+    {
+        $result = $this->calculator->calculate(SplitType::Percentage, '100.00', [
+            new ExpenseDebtRequest(1, '33.33'),
+            new ExpenseDebtRequest(2, '33.33'),
+            new ExpenseDebtRequest(3, '33.34'),
+        ]);
+
+        $this->assertSame('100.00', $this->sum($result));
+    }
+
+    /**
+     * @dataProvider nonEqualTypeProvider
+     */
+    public function testValueIsRequiredForNonEqualTypes(SplitType $splitType): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->calculator->calculate($splitType, '100.00', [
+            new ExpenseDebtRequest(1),
+        ]);
+    }
+
+    /**
+     * @return array<string, array{SplitType}>
+     */
+    public static function nonEqualTypeProvider(): array
+    {
+        return [
+            'exact' => [SplitType::Exact],
+            'percentage' => [SplitType::Percentage],
+            'shares' => [SplitType::Shares],
+        ];
+    }
+
+    /**
+     * @param list<array{payerId: int, amount: string, splitValue: ?string}> $result
+     */
+    private function sum(array $result): string
+    {
+        return array_reduce($result, fn (string $carry, array $debt) => bcadd($carry, $debt['amount'], 2), '0.00');
+    }
+}


### PR DESCRIPTION
Breaking payload change: debt lines send value instead of amount.

- add SplitType enum and persist split_type on Expense + split_value on Debt
- add SplitCalculator that derives per-debtor amounts (largest-remainder rounding)
  and centralises the debt-sum validation previously duplicated in create/update
- accept splitType on ExpenseRequest; rename debt request field amount -> value
- return splitType and debts (with splitValue) in expense responses
- add GET /api/expenses/{id} for reading an expense with its split back
- migration adds split_type (default 'exact') and nullable split_value